### PR TITLE
Hide layers that have property hidden = true

### DIFF
--- a/dist/Directives/wimLegend.js
+++ b/dist/Directives/wimLegend.js
@@ -270,7 +270,7 @@ var WiM;
                     '            </div>' +
                     '            <!-- overlays --> ' +
                     '            <div class="wimLegend-overlay-group" ng-repeat="layer in vm.overlays.layergroup" ng-init="vm.initLayers(layer)">' +
-                    '                <div ng-if="!layer.hasOwnProperty(\'group\')">' +
+                    '                <div ng-if="!layer.hasOwnProperty(\'group\') && (layer.hidden != true)">' +
                     '                <div ng-if="!layer.layerParams.showOnSelector && layer.layerParams.showOnSelector !== false" ng-class="!layer.isOpen  ? \'list-group-item-active wimLegend-list-group-item-active\': \'list-group-item wimLegend-list-group-item\'">' +
                     '                            <label for="checkbox{{$id}}" class="chx" ng-if="!layer.layerParams.showOnSelector && layer.layerParams.showOnSelector !== false" ng-click="layer.visible = (layer.visible) ? false : true;">' +
                     '                               <input type="checkbox" id="checkbox{{$id}}" ng-checked="layer.visible" />' +

--- a/src/Directives/wimLegend.js
+++ b/src/Directives/wimLegend.js
@@ -270,7 +270,7 @@ var WiM;
                     '            </div>' +
                     '            <!-- overlays --> ' +
                     '            <div class="wimLegend-overlay-group" ng-repeat="layer in vm.overlays.layergroup" ng-init="vm.initLayers(layer)">' +
-                    '                <div ng-if="!layer.hasOwnProperty(\'group\')">' +
+                    '                <div ng-if="!layer.hasOwnProperty(\'group\') && (layer.hidden != true)">' +
                     '                <div ng-if="!layer.layerParams.showOnSelector && layer.layerParams.showOnSelector !== false" ng-class="!layer.isOpen  ? \'list-group-item-active wimLegend-list-group-item-active\': \'list-group-item wimLegend-list-group-item\'">' +
                     '                            <label for="checkbox{{$id}}" class="chx" ng-if="!layer.layerParams.showOnSelector && layer.layerParams.showOnSelector !== false" ng-click="layer.visible = (layer.visible) ? false : true;">' +
                     '                               <input type="checkbox" id="checkbox{{$id}}" ng-checked="layer.visible" />' +

--- a/src/Directives/wimLegend.ts
+++ b/src/Directives/wimLegend.ts
@@ -346,7 +346,7 @@ module WiM.Directives {
         '            </div>' +
         '            <!-- overlays --> ' +
         '            <div class="wimLegend-overlay-group" ng-repeat="layer in vm.overlays.layergroup" ng-init="vm.initLayers(layer)">' +
-        '                <div ng-if="!layer.hasOwnProperty(\'group\')">' +
+        '                <div ng-if="!layer.hasOwnProperty(\'group\') && (layer.hidden != true)">' +
         '                <div ng-if="!layer.layerParams.showOnSelector && layer.layerParams.showOnSelector !== false" ng-class="!layer.isOpen  ? \'list-group-item-active wimLegend-list-group-item-active\': \'list-group-item wimLegend-list-group-item\'">' +
         '                            <label for="checkbox{{$id}}" class="chx" ng-if="!layer.layerParams.showOnSelector && layer.layerParams.showOnSelector !== false" ng-click="layer.visible = (layer.visible) ? false : true;">' +
         '                               <input type="checkbox" id="checkbox{{$id}}" ng-checked="layer.visible" />' +


### PR DESCRIPTION
Relevant to https://github.com/USGS-WiM/streamstats/issues/1365
Test in https://github.com/USGS-WiM/StreamStats/pull/1372

If an overlay layer in the appConfig.js in StreamStats has the following line, the layer will not appear in the legend:
`hidden": true,`

This will allow a layer to be queried in StreamStats without it being visible on the map or legend.