### PR TITLE
Fix for removing geojson from the legend

### DIFF
--- a/dist/Directives/wimLegend.js
+++ b/dist/Directives/wimLegend.js
@@ -202,7 +202,7 @@ var WiM;
                 if (this.applicationLayer.layergroup.hasOwnProperty(e.LayerName))
                     return;
                 this.applicationLayer.isAvailable = true;
-                this.applicationLayer.layergroup[e.LayerName] = {
+                this.applicationLayer.layergroup.layergroup[e.LayerName] = {
                     visible: e.visible,
                     style: e.style
                 };

--- a/dist/Directives/wimLegend.js
+++ b/dist/Directives/wimLegend.js
@@ -202,7 +202,7 @@ var WiM;
                 if (this.applicationLayer.layergroup.hasOwnProperty(e.LayerName))
                     return;
                 this.applicationLayer.isAvailable = true;
-                this.applicationLayer.layergroup.layergroup[e.LayerName] = {
+                this.applicationLayer.layergroup[e.LayerName] = {
                     visible: e.visible,
                     style: e.style
                 };
@@ -211,7 +211,7 @@ var WiM;
                 if (e.layerType != 'geojson')
                     return;
                 if (this.applicationLayer.layergroup.hasOwnProperty(e.LayerName))
-                    delete this.applicationLayer[e.LayerName];
+                    delete this.applicationLayer.layergroup[e.LayerName];
             };
             return wimLegendController;
         }(WiM.Services.HTTPServiceBase));

--- a/src/Directives/wimLegend.js
+++ b/src/Directives/wimLegend.js
@@ -211,7 +211,7 @@ var WiM;
                 if (e.layerType != 'geojson')
                     return;
                 if (this.applicationLayer.layergroup.hasOwnProperty(e.LayerName))
-                    delete this.applicationLayer[e.LayerName];
+                    delete this.applicationLayer.layergroup[e.LayerName];
             };
             return wimLegendController;
         }(WiM.Services.HTTPServiceBase));

--- a/src/Directives/wimLegend.ts
+++ b/src/Directives/wimLegend.ts
@@ -284,7 +284,7 @@ module WiM.Directives {
             if (e.layerType != 'geojson') return; 
             //remove
             if (this.applicationLayer.layergroup.hasOwnProperty(e.LayerName))
-                delete this.applicationLayer[e.LayerName];
+                delete this.applicationLayer.layergroup[e.LayerName];
         }
 
     }//end wimLayerControlController class


### PR DESCRIPTION
Related to https://github.com/USGS-WiM/StreamStats/issues/1125 and part of https://github.com/USGS-WiM/StreamStats/issues/1852

To test: 
Test in the StreamStats dev branch by changing "wim_angular": "github:usgs-wim/wim_angular#HW-geojsonfix" in package.json and then npm install
After confirming that it works, approve and merge this PR
Change back to wim_angular#master_streamstats in package.json and again npm install
Confirm everything still works